### PR TITLE
Don't assume `output` has a `log` property.

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -16,7 +16,7 @@ Instantiate a new logger like this:
 
     const log = new Logger({
       now: Date.now,
-      output: console,
+      output: console.log,
       events: {
         startup: 'startup',
         exception: 'exception',

--- a/node/logger.js
+++ b/node/logger.js
@@ -1,11 +1,19 @@
 class Logger {
   constructor (configuration, scopedProperties) {
+    const {now, output, events} = configuration
     this.configuration = configuration
+    this.now = now
+    if (output.log) {
+      this.output = output.log.bind(output)
+    } else {
+      this.output = output
+    }
+    this.events = events
     this.scopedProperties = scopedProperties
 
-    const EventLogger = makeEventLogger(this.configuration, this.scopedProperties)
-    for (let name in this.configuration.events) {
-      const eventType = this.configuration.events[name]
+    const EventLogger = makeEventLogger({now: this.now, output: this.output}, this.scopedProperties)
+    for (let name in events) {
+      const eventType = events[name]
       this[name] = new EventLogger(eventType)
     }
   }

--- a/node/logger.js
+++ b/node/logger.js
@@ -29,7 +29,7 @@ const makeEventLogger = ({now, output}, scopedProperties) => {
     }
 
     const allProperties = Object.assign({}, defaultProperties, scopedProperties, extraProperties)
-    output.log(JSON.stringify(allProperties))
+    output(JSON.stringify(allProperties))
   }
 
   return class {

--- a/node/test-logger.js
+++ b/node/test-logger.js
@@ -14,7 +14,7 @@ const fromLogMessage = function (output, {atIndex = 0} = {}) {
 describe('logging', function () {
   beforeEach(function () {
     this.timestamp = moment.utc('2016-02-15T12:34:56.789Z')
-    this.output = {log: sinon.spy()}
+    this.output = sinon.spy()
     this.log = new Logger({
       now: () => this.timestamp,
       output: this.output,
@@ -29,7 +29,7 @@ describe('logging', function () {
   it('should log all required components', function () {
     this.log.exception.error()
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents).to.have.property('timestamp', '2016-02-15T12:34:56.789Z')
     expect(contents).to.have.property('event_type', 'exception')
@@ -48,7 +48,7 @@ describe('logging', function () {
     }
     this.log.exception.error(extraProperties)
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents.correlation_id).to.equal('126bb6fa-28a2-470f-b013-eefbf9182b2d')
     expect(contents.request.method).to.equal('GET')
@@ -67,7 +67,7 @@ describe('logging', function () {
     const log = this.log.with(scopedProperties)
     log.lunchtime.error(extraProperties)
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents).to.have.property('service', 'object creation factory maker')
     expect(contents).to.have.property('something', 'shiny')
@@ -88,7 +88,7 @@ describe('logging', function () {
     const log = this.log.with(scopedProperties).with(additionalScopedProperties)
     log.lunchtime.error(extraProperties)
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents).to.have.property('beverage', 'orange soda')
     expect(contents).to.have.property('sandwich', 'noodle')
@@ -111,7 +111,7 @@ describe('logging', function () {
 
     log.lunchtime.error(extraProperties)
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents).to.not.have.property('dog')
     expect(contents).to.have.property('cat', 'ginger')
@@ -121,7 +121,7 @@ describe('logging', function () {
   it('converts strings into an object', function () {
     this.log.startup.info('Hello!')
 
-    const contents = fromLogMessage(this.output.log)
+    const contents = fromLogMessage(this.output)
 
     expect(contents).to.have.property('message', 'Hello!')
   })
@@ -130,7 +130,7 @@ describe('logging', function () {
     it(`should accept ${severity} as a severity`, function () {
       this.log.startup[severity]()
 
-      const contents = fromLogMessage(this.output.log)
+      const contents = fromLogMessage(this.output)
 
       expect(contents).to.have.property('severity')
         .that.equals(severity.toUpperCase())

--- a/node/test-logger.js
+++ b/node/test-logger.js
@@ -136,4 +136,33 @@ describe('logging', function () {
         .that.equals(severity.toUpperCase())
     })
   })
+
+  it('allows just passing `console` too, for backwards compatibility', function () {
+    const fakeConsole = new FakeConsole(this.output)
+    const log = new Logger({
+      now: () => this.timestamp,
+      output: fakeConsole,
+      events: {
+        'startup': 'startup',
+        'exception': 'exception',
+        'lunchtime': 'lunch time'
+      }
+    })
+
+    log.exception.info({foo: 'bar'})
+
+    const contents = fromLogMessage(this.output)
+
+    expect(contents).to.have.property('foo', 'bar')
+  })
+
+  class FakeConsole {
+    constructor (output) {
+      this.output = output
+    }
+
+    log (...args) {
+      this.output(...args)
+    }
+  }
 })


### PR DESCRIPTION
Otherwise we're prevented from using another logging mechanism
(for example, `process.stdout.write` or a file).